### PR TITLE
Fast pid cmi larger mi issue

### DIFF
--- a/idtxl/estimators_fast_pid_ext_rep.py
+++ b/idtxl/estimators_fast_pid_ext_rep.py
@@ -1,6 +1,8 @@
 import sys
 import numpy as np
 
+import jpype as jp
+
 def pid(s1, s2, t, cfg):
     """Provide a fast implementation of the PDI estimator for discrete data.
 
@@ -53,7 +55,7 @@ the unique information from sources 1 and 2.
     except KeyError:
         print('"max_iters" is missing from the cfg dictionary.')
         raise
-
+    
     # -- DEFINE PARAMETERS -- #
 
     num_samples = len(t)
@@ -110,9 +112,33 @@ the unique information from sources 1 and 2.
 #    joint_t_s1_s2_prob_alt = joint_t_s1_s2_prob.copy()
 
 
+    # JIDT IS BACK
 
+    jarpath = '/home/conor/projects/idtxl/git/IDTxl/idtxl/infodynamics.jar'
+    
+    if not jp.isJVMStarted():
+        jp.startJVM(jp.getDefaultJVMPath(),
+                    '-ea', '-Djava.class.path=' + jarpath)
 
+    Cmi_calc_class = (jp.JPackage('infodynamics.measures.discrete')
+                      .ConditionalMutualInformationCalculatorDiscrete)
+    Mi_calc_class = (jp.JPackage('infodynamics.measures.discrete')
+                     .MutualInformationCalculatorDiscrete)
 
+    cmi_calc_t_s1_cond_s2 = Cmi_calc_class(alph_t,alph_s1,alph_s2)
+    cmi_calc_t_s2_cond_s1 = Cmi_calc_class(alph_t,alph_s2,alph_s1)
+    cmi_t_s1_cond_s2 = _calculate_cmi(cmi_calc_t_s1_cond_s2, t, s1, s2)
+    cmi_t_s2_cond_s1 = _calculate_cmi(cmi_calc_t_s2_cond_s1, t, s2, s1)
+
+    alph_max = max(alph_s1*alph_s2, alph_t)
+    jointmi_calc  = Mi_calc_class(alph_max)
+    jointmi_s1s2_t = _calculate_jointmi(jointmi_calc, s1, s2, t)
+    
+    print('JIDT CMI (s1):\t', cmi_t_s2_cond_s1)    
+    print('JIDT CMI (s2):\t', cmi_t_s1_cond_s2)
+    print('JIDT JMI:\t', jointmi_s1s2_t)
+
+    
     # -- VIRTUALISED SWAPS -- #
 
     # Calculate the initial cmi's and store them
@@ -127,11 +153,11 @@ the unique information from sources 1 and 2.
     # sanity check: the curr cmi must be smaller than the joint, else something
     # is fishy
     #
-    jointmi_s1s2_target = _joint_mi(s1, s2, t, alph_s1, alph_s2, alph_t)
+    jointmi_s1s2_t = _joint_mi(s1, s2, t, alph_s1, alph_s2, alph_t)
 
-    if cond_mut_info1 > jointmi_s1s2_target:
+    if cond_mut_info1 > jointmi_s1s2_t:
         raise ValueError('joint MI {0} smaller than cMI {1}'
-                         ''.format(jointmi_s1s2_target, cond_mut_info1))
+                         ''.format(jointmi_s1s2_t, cond_mut_info1))
     else:
         print('Passed sanity check on jMI and cMI')
 
@@ -283,7 +309,8 @@ def _cmi_prob(s2cond_prob, joint_t_s2cond_prob,
         for sym_s2cond in range(0, alph_s2cond):
             for sym_t in range(0, alph_t):
 
-                if ( s2cond_prob[sym_s2cond] * joint_t_s2cond_prob[sym_t, sym_s2cond]
+                if ( s2cond_prob[sym_s2cond]
+                     * joint_t_s2cond_prob[sym_t, sym_s2cond]
                      * joint_s1_s2cond_prob[sym_s1, sym_s2cond]
                      * joint_t_s1_s2cond_prob[sym_t, sym_s1, sym_s2cond] > 0 ):
 
@@ -407,6 +434,59 @@ def _join_variables(a, b, alph_a, alph_b):
     } '''
 
     return joined.astype(int), alph_new
+
+
+
+
+def _calculate_cmi(cmi_calc, var_1, var_2, cond):
+    """Calculate conditional MI from three variables usind JIDT.
+
+    Args:
+        cmi_calc (JIDT calculator object): JIDT calculator for conditio-
+            nal mutual information
+        var_1, var_2 (1D numpy array): realizations of two discrete
+            random variables
+        cond (1D numpy array): realizations of a discrete random
+            variable for conditioning
+
+    Returns:
+        double: conditional mutual information between var_1 and var_2
+            conditional on cond
+    """
+    var_1_java = jp.JArray(jp.JInt, var_1.ndim)(var_1.tolist())
+    var_2_java = jp.JArray(jp.JInt, var_2.ndim)(var_2.tolist())
+    cond_java = jp.JArray(jp.JInt, cond.ndim)(cond.tolist())
+    cmi_calc.initialise()
+    cmi_calc.addObservations(var_1_java, var_2_java, cond_java)
+    cmi = cmi_calc.computeAverageLocalOfObservations()
+    return cmi
+
+def _calculate_jointmi(jointmi_calc, s1, s2, target):
+    """Calculate MI from three variables usind JIDT.
+
+    Args:
+        jointmi_calc (JIDT calculator object): JIDT calculator for
+            mutual information
+        var_1, var_2, var_3 (1D numpy array): realizations of some
+            discrete random variables
+
+    Returns:
+        double: mutual information between all three input variables
+    """
+    mUtils = jp.JPackage('infodynamics.utils').MatrixUtils
+    # speed critical line ?
+    s12 = mUtils.computeCombinedValues(jp.JArray(jp.JInt, 2)(np.column_stack((s1, s2)).tolist()), 2)
+#    [s12, alph_joined] = _join_variables(s1, s2, 2, 2)
+    jointmi_calc.initialise()
+#    jointmi_calc.addObservations(jp.JArray(jp.JInt, s12.T.ndim)(s12.T.tolist()),
+#                                 jp.JArray(jp.JInt, target.ndim)(target.tolist()))
+    jointmi_calc.addObservations(s12,jp.JArray(jp.JInt, target.ndim)(target.tolist()))
+
+    jointmi = jointmi_calc.computeAverageLocalOfObservations()
+    return jointmi
+
+
+
 
 # TODO fix this - no idea why it does not yield the correct results
 #def _try_swap(cur_cond_mut_info, joint_t_s1_s2_prob, joint_s1_s2_prob,

--- a/idtxl/estimators_fast_pid_ext_rep.py
+++ b/idtxl/estimators_fast_pid_ext_rep.py
@@ -155,7 +155,7 @@ the unique information from sources 1 and 2.
     # sanity check: the curr cmi must be smaller than the joint, else something
     # is fishy
     #
-    jointmi_s1s2_t = _joint_mi(s1, s2, t, alph_s1, alph_s2, alph_t)
+    jointmi_s1s2_t = _joint_mi(jointmi_calc, alph_max, s1, s2, t, alph_s1, alph_s2, alph_t)
 
     print('CMI (s1): ', cond_mut_info2)    
     print('CMI (s2): ', cond_mut_info1)
@@ -367,13 +367,18 @@ def _mi_prob(s1_prob, s2_prob, joint_s1_s2_prob):
     return total
 
 
-def _joint_mi(s1, s2, t, alph_s1, alph_s2, alph_t):
+def _joint_mi(jointmi_calc, alph_max, s1, s2, t, alph_s1, alph_s2, alph_t):
     """
     Joint MI calculator in the samples domain
     """
 
-    [s12, alph_s12] = _join_variables(s1, s2, alph_s1, alph_s2)
+    #[s12, alph_s12] = _join_variables(s1, s2, alph_s1, alph_s2)
 
+    mUtils = jp.JPackage('infodynamics.utils').MatrixUtils
+    # speed critical line ?
+    s12 = mUtils.computeCombinedValues(jp.JArray(jp.JInt, 2)(np.column_stack((s1, s2)).tolist()), 2)
+    alph_s12 = alph_max
+    
     t_count = np.zeros(alph_t, dtype=np.int)
     s12_count = np.zeros(alph_s12, dtype=np.int)
     joint_t_s12_count = np.zeros((alph_t, alph_s12), dtype=np.int)

--- a/idtxl/estimators_fast_pid_ext_rep.py
+++ b/idtxl/estimators_fast_pid_ext_rep.py
@@ -127,16 +127,16 @@ the unique information from sources 1 and 2.
 
     cmi_calc_t_s1_cond_s2 = Cmi_calc_class(alph_t,alph_s1,alph_s2)
     cmi_calc_t_s2_cond_s1 = Cmi_calc_class(alph_t,alph_s2,alph_s1)
-    cmi_t_s1_cond_s2 = _calculate_cmi(cmi_calc_t_s1_cond_s2, t, s1, s2)
-    cmi_t_s2_cond_s1 = _calculate_cmi(cmi_calc_t_s2_cond_s1, t, s2, s1)
+    cmi_t_s1_cond_s2_jidt = _calculate_cmi(cmi_calc_t_s1_cond_s2, t, s1, s2)
+    cmi_t_s2_cond_s1_jidt = _calculate_cmi(cmi_calc_t_s2_cond_s1, t, s2, s1)
 
     alph_max = max(alph_s1*alph_s2, alph_t)
     jointmi_calc  = Mi_calc_class(alph_max)
-    jointmi_s1s2_t = _calculate_jointmi(jointmi_calc, s1, s2, t)
+    jointmi_s1s2_t_jidt = _calculate_jointmi(jointmi_calc, s1, s2, t)
     
-    print('JIDT CMI (s1):\t', cmi_t_s2_cond_s1)    
-    print('JIDT CMI (s2):\t', cmi_t_s1_cond_s2)
-    print('JIDT JMI:\t', jointmi_s1s2_t)
+    print('JIDT CMI (s1): ', cmi_t_s2_cond_s1_jidt)    
+    print('JIDT CMI (s2): ', cmi_t_s1_cond_s2_jidt)
+    print('JIDT JMI:      ', jointmi_s1s2_t_jidt)
 
     
     # -- VIRTUALISED SWAPS -- #
@@ -147,7 +147,9 @@ the unique information from sources 1 and 2.
     cur_cond_mut_info1 = cond_mut_info1
 
     cond_mut_info2 = _cmi_prob(
-        s1_prob, joint_t_s1_prob, joint_s1_s2_prob, joint_t_s1_s2_prob)
+        s1_prob, joint_t_s1_prob,
+        np.transpose(joint_s1_s2_prob), # transpose s1 and s2
+        np.ndarray.transpose(joint_t_s1_s2_prob,[0,2,1])) # ditto
     cur_cond_mut_info2 = cond_mut_info2
 
     # sanity check: the curr cmi must be smaller than the joint, else something
@@ -155,6 +157,10 @@ the unique information from sources 1 and 2.
     #
     jointmi_s1s2_t = _joint_mi(s1, s2, t, alph_s1, alph_s2, alph_t)
 
+    print('CMI (s1): ', cond_mut_info2)    
+    print('CMI (s2): ', cond_mut_info1)
+    print('JMI:      ', jointmi_s1s2_t)
+    
     if cond_mut_info1 > jointmi_s1s2_t:
         raise ValueError('joint MI {0} smaller than cMI {1}'
                          ''.format(jointmi_s1s2_t, cond_mut_info1))

--- a/idtxl/estimators_fast_pid_ext_rep.py
+++ b/idtxl/estimators_fast_pid_ext_rep.py
@@ -116,10 +116,11 @@ the unique information from sources 1 and 2.
         s2_prob, joint_t_s2_prob, joint_s1_s2_prob, joint_t_s1_s2_prob)
     cur_cond_mut_info1 = cond_mut_info1
 
+    joint_s2_s1_prob = np.transpose(joint_s1_s2_prob)
+    joint_t_s2_s1_prob = np.ndarray.transpose(joint_t_s1_s2_prob,[0,2,1])
+
     cond_mut_info2 = _cmi_prob(
-        s1_prob, joint_t_s1_prob,
-        np.transpose(joint_s1_s2_prob), # transpose s1 and s2
-        np.ndarray.transpose(joint_t_s1_s2_prob,[0,2,1])) # ditto
+        s1_prob, joint_t_s1_prob, joint_s2_s1_prob,joint_t_s2_s1_prob)
     cur_cond_mut_info2 = cond_mut_info2
 
     # sanity check: the curr cmi must be smaller than the joint, else something

--- a/test/PID_analysis_cultures_single_combination.py
+++ b/test/PID_analysis_cultures_single_combination.py
@@ -10,6 +10,10 @@ import json
 import scipy.io as sio
 import numpy as np
 import time as tm
+#from idtxl.estimators_fast_pid_ext_rep import pid
+
+import sys
+sys.path.insert(0, '/home/conor/projects/idtxl/git/IDTxl')
 from idtxl.estimators_fast_pid_ext_rep import pid
 
 
@@ -85,9 +89,10 @@ if __name__ == '__main__' :
     args = parser.parse_args()
     day = args.day
 
-    datapath = ('/home/wibral/unison/projects/'
-                'TransferEntropy/Application_Projects/'
-                'Culture_PID/')
+#    datapath = ('/home/wibral/unison/projects/'
+#                'TransferEntropy/Application_Projects/'
+#                'Culture_PID/')    
+    datapath = ('/home/conor/projects/idtxl/git/IDTxl/test/data/')
     first_channels = ['53']
     second_channels = ['17']
 

--- a/test/PID_analysis_cultures_single_combination.py
+++ b/test/PID_analysis_cultures_single_combination.py
@@ -10,10 +10,6 @@ import json
 import scipy.io as sio
 import numpy as np
 import time as tm
-#from idtxl.estimators_fast_pid_ext_rep import pid
-
-import sys
-sys.path.insert(0, '/home/conor/projects/idtxl/git/IDTxl')
 from idtxl.estimators_fast_pid_ext_rep import pid
 
 
@@ -89,10 +85,9 @@ if __name__ == '__main__' :
     args = parser.parse_args()
     day = args.day
 
-#    datapath = ('/home/wibral/unison/projects/'
-#                'TransferEntropy/Application_Projects/'
-#                'Culture_PID/')    
-    datapath = ('/home/conor/projects/idtxl/git/IDTxl/test/data/')
+    datapath = ('/home/wibral/unison/projects/'
+                'TransferEntropy/Application_Projects/'
+                'Culture_PID/')
     first_channels = ['53']
     second_channels = ['17']
 


### PR DESCRIPTION
Hi everyone,

It appears the bug has been resolved.

Rewriting `_join_variable` function independently appears to have fixed the final issue. At least, it seems to work for the test case _PID_analysis_cultures_single_combination.py_, i.e:
```
    CMI (s1):  [ 3.079244e-05]
    CMI (s2):  [ 0.00087705259]
    JMI:       [ 0.00088211734]
    Passed sanity check on jMI and cMI
    num_reps:
    62
    jointmi_s1s2_target: [ 0.00088211734]
    unq_s1: [ 0.00085262779]
    unq_s2: [ 6.3676397e-06]
    shd_s1_s2: [-1.3028898e-06]
    syn_s1_s2:[ 2.44248e-05]

    Total elapsed time: 8.261477 seconds
```
I think it should be tested further at your end before it is merged as it has only been tested on that one data set here. Who knows what horrors might still be lurking. This [link](https://help.github.com/articles/checking-out-pull-requests-locally/) might be the best way to go about doing that. Or if you are feeling lazy you can just clone my whole fork into a separate folder and checkout to the branch found [here](https://github.com/finnconor/IDTxl/tree/fast_PID_cmi_larger_mi_issue). 

Michael, you (hopefully) shouldn't need to change any configuration settings as I reverted _PID_analysis_cultures_single_combination.py_ back to your last commit with my last commit. 

For the purpose of full disclosure I should tell you that there is still a discrepancy between this implementation and tests I was doing with python/jpype called JIDT. However, it appears the issue is something to do with how JIDT is being called or some other issue -- I will look into it some more tomorrow. These are the results which as you can see still suffer from the issue:
```
    JIDT CMI (s1):  3.079243959569562e-05
    JIDT CMI (s2):  0.0008770525912776734
    JIDT JMI:       0.0008360450690665427
```
If this is resolved I will look to improve how the so-called starvation problem is handled.

Let me know if there is anything that requires further clarification.

Talk soon,
Conor