### PR TITLE
MPI support for IDTxl

### DIFF
--- a/demos/demo_multivariate_te_mpi.py
+++ b/demos/demo_multivariate_te_mpi.py
@@ -1,0 +1,54 @@
+# Import classes
+from idtxl.multivariate_te import MultivariateTE
+from idtxl.data import Data
+from idtxl.visualise_graph import plot_network
+import matplotlib.pyplot as plt
+import time
+import sys
+
+from mpi4py import MPI
+
+def main(args):
+    """Demo of how to use the MPIEstimator for network analysis
+    Call this script using
+    mpiexec -n 1 python demos/demo_multivariate_te_mpi.py <number of workers>
+    for systems supporting MPI Spawn (MPI version >= 2) or
+    mpiexec -n <number of workers + 1> python -m mpi4py.futures demo/demo_multivariate_te_mpi.py <number of workers>
+    for legacy MPI 1 implementations.
+    
+    Call
+    python demos/demo_multivariate_te_mpi.py 0
+    for a comparison without MPI.
+
+    """
+    assert MPI.COMM_WORLD.Get_rank() == 0 
+
+    max_workers = int(args[1])
+    print(f'Running TE Test with {max_workers} MPI workers.')
+
+    # a) Generate test data
+    data = Data(seed=12345)
+    data.generate_mute_data(n_samples=1000, n_replications=5)
+
+    # b) Initialise analysis object and define settings
+    network_analysis = MultivariateTE()
+    settings = {'cmi_estimator': 'JidtGaussianCMI',
+                'max_lag_sources': 5,
+                'min_lag_sources': 1,
+                'MPI': max_workers > 0,
+                'max_workers': max_workers
+                }
+
+    # c) Run analysis
+    start = time.time()
+    results = network_analysis.analyse_network(settings=settings, data=data)
+    end = time.time()
+    print(f'On {max_workers} workers, the task took {end - start} seconds.')
+
+    # d) Plot inferred network to console and via matplotlib
+    results.print_edge_list(weights='max_te_lag', fdr=False)
+    plot_network(results=results, weights='max_te_lag', fdr=False)
+    plt.show()
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/demos/demo_multivariate_te_mpi_slurm.sh
+++ b/demos/demo_multivariate_te_mpi_slurm.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# This bash script runs the demo_multivariate_te_mpi.py with several different settings on a SLURM batch system.
+# Submit using command "sbatch demo_multivariate_te_mpi_slurm.sh".
+#
+#SBATCH --job-name=te_mpi
+#SBATCH --output=demo_multivariate_te_mpi_res.txt
+#SBATCH --time=2:00:00
+#SBATCH --ntasks=4
+#SBATCH --tasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=4gb
+
+cd /usr/users/$USER
+
+export PYTHONPATH=/usr/users/$USER/IDTxl
+export JAVA_HOME=/usr/users/$USER/jdk-16.0.1
+
+date
+
+# Run on four nodes using MPI
+srun --nodes 4 -n 4 --mpi=pmi2 python -m mpi4py.futures "IDTxl/demos/demo_multivariate_te_mpi.py" 3
+wait
+date
+
+# Run on three nodes using MPI
+srun --nodes 3 -n 3 --mpi=pmi2 python -m mpi4py.futures "IDTxl/demos/demo_multivariate_te_mpi.py" 2
+wait
+date
+
+# Run on two nodes using MPI
+srun --nodes 2 -n 2 --mpi=pmi2 python -m mpi4py.futures "IDTxl/demos/demo_multivariate_te_mpi.py" 1
+wait
+date
+
+# Run on one node not using MPI
+srun --nodes 1 -n 1 --mpi=pmi2 python -m mpi4py.futures "IDTxl/demos/demo_multivariate_te_mpi.py" 0
+wait
+date

--- a/idtxl/bivariate_pid.py
+++ b/idtxl/bivariate_pid.py
@@ -7,7 +7,7 @@ Note:
 """
 import numpy as np
 from .single_process_analysis import SingleProcessAnalysis
-from .estimator import find_estimator
+from .estimator import get_estimator
 from .results import ResultsPID
 
 
@@ -206,11 +206,8 @@ class BivariatePID(SingleProcessAnalysis):
     def _initialise(self, settings, data, target, sources):
         """Check input, set initial or default values for analysis settings."""
         # Check requested PID estimator.
-        try:
-            EstimatorClass = find_estimator(settings['pid_estimator'])
-        except KeyError:
-            raise RuntimeError('Estimator was not specified!')
-        self._pid_estimator = EstimatorClass(settings)
+        assert 'pid_estimator' in settings, 'Estimator was not specified!'
+        self._pid_estimator = get_estimator(settings['pid_estimator'], settings)
 
         self.settings = settings.copy()
         self.settings.setdefault('lags_pid', [1, 1])

--- a/idtxl/estimators_mpi.py
+++ b/idtxl/estimators_mpi.py
@@ -1,0 +1,158 @@
+from .estimator import Estimator
+from .estimator import get_estimator
+from . import idtxl_exceptions as ex
+import numpy as np
+
+try:
+    from mpi4py.futures import MPIPoolExecutor
+except ImportError as err:
+    ex.package_missing(err, 'MPI is not available on this system. Install it'
+                       'from https://pypi.org/project/mpi4py/ to use'
+                       'MPI parallelization.')
+    raise err
+
+
+class MPIEstimator(Estimator):
+    """MPI Wrapper for arbitrary Estimator implementations
+
+    Upon calling estimate, one instance of the base Estimator is created
+    on each worker rank.
+
+    Requires MPI 2 or later as MPIPoolExecutor makes use of the spawn command.
+
+    Make sure to have an "if __name__=='__main__':" guard in your script to avoid
+    infinite recursion!
+
+    Call using mpiexec:
+    mpiexec -n 1 -usize <max workers + 1> python <python script>
+
+    Call using slurm:
+    srun -n $SLURM_NTASKS --mpi=pmi2 python -m mpi4py.futures <python script> 
+
+    """
+
+    def __init__(self, est, settings):
+        """Creates new MPIEstimator instance
+
+        Args:
+            est (str): Name of the base Estimator
+            settings (dict): settings for the base Estimator.
+                max_workers (optional): Number of MPI workers. Default: MPI_UNIVERSE_SIZE
+        """
+
+        self._settings = self._check_settings(settings).copy()
+        self._settings['estimator'] = est
+
+        # Create the MPIPoolExecutor
+        self._executor = MPIPoolExecutor(
+            max_workers=self._settings.get('max_workers', None))
+
+        # Create Estimator for rank 0.
+        self._estimator = self._create_estimator()
+
+    def __del__(self):
+        """De-initializer
+
+        """
+
+        # If this is rank 0, clean up MPIPoolExecutor
+        if self._executor is not None:
+            self._executor.shutdown()
+
+    def __getstate__(self):
+        """Returns the state dict of the MPIEstimator instance for pickling.
+
+        Called on rank 0 to broadcast self to the workers.
+        Exclude both self._executor and self._estimator from pickling.
+
+        Returns:
+            dict: [description]
+        """
+
+        # Do not pickle _executor or _estimator.
+        state = self.__dict__.copy()
+        del state['_executor']
+        del state['_estimator']
+        return state
+
+    def __setstate__(self, state):
+        """Restores the instance from a pickle state dict.
+
+        Called on worker ranks.
+        self._executor is not necessar on the worker ranks, but a static _estimator is created.
+
+        Args:
+            state (dict): state dictionary
+        """
+
+        # Restore instance attributes (exept for self._executor and self._estimator).
+        self.__dict__.update(state)
+        self._executor = None
+
+        # Create separate Estimator instances on the worker ranks
+        self._estimator = self._create_estimator()
+
+    def _create_estimator(self):
+        """Creates the Estimator
+
+        """
+
+        return get_estimator(self._settings['estimator'], self._settings)
+
+    def estimate(self, n_chunks=1, **data):
+        """Distributes the given chunks of a task to Estimators on worker ranks using MPI.
+
+        Needs to be called with kwargs only.
+
+        Args:
+            n_chunks (int, optional): Number of chunks to split the data into. Defaults to 1.
+
+        Returns:
+            numpy array: Estimates of information-theoretic quantities
+        """
+
+        assert n_chunks > 0, 'Number of chunks must be at least one.'
+
+        samplesize = len(list(data.values())[0])
+
+        assert all(var is None or len(var) == samplesize for var in data.values(
+        )), 'All variables must have the same number of realizations.'
+
+        # Split the data into chunks
+        chunksize = samplesize // n_chunks
+
+        chunked_data = ({var: (None if data[var] is None else data[var][i*chunksize:min(
+            (i+1)*chunksize, samplesize)]) for var in data} for i in range(n_chunks))
+
+        # This call implicitly pickles self and sends it to the worker ranks along with the chunked data
+        return np.fromiter(self._executor.map(self._estimate_single_chunk, chunked_data), dtype=np.double)
+
+    def _estimate_single_chunk(self, data):
+        """Estimates a single chunk of data on an MPI worker rank.
+
+        Calls the estimate function of the base Estimator
+
+        """
+
+        if self._estimator.is_parallel():
+            return self._estimator.estimate(n_chunks=1, **data)
+        else:
+            return self._estimator.estimate(**data)
+
+    def is_parallel(self):
+        return True
+
+    def is_analytic_null_estimator(self):
+        """Test if the base Estimator is an analytic null estimator.
+
+        """
+
+        return self._estimator.is_analytic_null_estimator()
+
+    def estimate_surrogates_analytic(self, **data):
+        """Forward analytic estimation to the base Estimator.
+
+        Analytic estimation is assumed to have negligible runtime and is thus performed on rank 0 alone.
+        """
+
+        return self._estimator.estimate_surrogates_analytic(**data)

--- a/idtxl/estimators_mpi.py
+++ b/idtxl/estimators_mpi.py
@@ -1,6 +1,7 @@
 from .estimator import Estimator
 from .estimator import get_estimator
 from . import idtxl_exceptions as ex
+from .idtxl_utils import timeout
 
 import numpy as np
 import itertools
@@ -93,7 +94,10 @@ class MPIEstimator(Estimator):
         self._executor = MPIPoolExecutor(
             max_workers=settings.get('max_workers', None))
 
-        self._executor.bootup(wait=True)
+        # Boot up the executor with timeout
+        with timeout(timeout_duration=10, exception_message='Failed to boot up MPIPoolExecutor. Make sure to start script in MPI environment, \
+                                                                i.e. using mpiexec, mpirun, srun (on SLURM) or equivalent.'):
+            self._executor.bootup(wait=True)
 
         # Create Estimator for rank 0.
         _get_worker_estimator(self._id, est, settings)

--- a/idtxl/estimators_mpi.py
+++ b/idtxl/estimators_mpi.py
@@ -45,7 +45,7 @@ class MPIEstimator(Estimator):
 
         # Create the MPIPoolExecutor
         self._executor = MPIPoolExecutor(
-            max_workers=self._settings.get('max_workers', None))
+            max_workers=self._settings.get('max_workers', None), path=['./test'])
 
         # Create Estimator for rank 0.
         self._estimator = self._create_estimator()

--- a/idtxl/estimators_mpi.py
+++ b/idtxl/estimators_mpi.py
@@ -95,8 +95,9 @@ class MPIEstimator(Estimator):
             max_workers=settings.get('max_workers', None))
 
         # Boot up the executor with timeout
-        with timeout(timeout_duration=settings.get('mpi_bootup_timeout', 10), exception_message='Failed to boot up MPIPoolExecutor. Make sure to start script in MPI environment, \
-                                                                i.e. using mpiexec, mpirun, srun (on SLURM) or equivalent.'):
+        with timeout(timeout_duration=settings.get('mpi_bootup_timeout', 10), exception_message='Bootup of MPI workers timed out.\n\
+                Make sure the script was started in an MPI enrivonment using mpiexec, mpirun, srun (SLURM) or equivalent.\n\
+                If necessary, increase the timeout in the settings dictionary using the key mpi_bootup_timeout.'):
             self._executor.bootup(wait=True)
 
         # Create Estimator for rank 0.

--- a/idtxl/estimators_mpi.py
+++ b/idtxl/estimators_mpi.py
@@ -95,7 +95,7 @@ class MPIEstimator(Estimator):
             max_workers=settings.get('max_workers', None))
 
         # Boot up the executor with timeout
-        with timeout(timeout_duration=10, exception_message='Failed to boot up MPIPoolExecutor. Make sure to start script in MPI environment, \
+        with timeout(timeout_duration=settings.get('mpi_bootup_timeout', 10), exception_message='Failed to boot up MPIPoolExecutor. Make sure to start script in MPI environment, \
                                                                 i.e. using mpiexec, mpirun, srun (on SLURM) or equivalent.'):
             self._executor.bootup(wait=True)
 

--- a/idtxl/idtxl_utils.py
+++ b/idtxl/idtxl_utils.py
@@ -1,6 +1,7 @@
 """Provide IDTxl utility functions."""
 import pprint
 import numpy as np
+import threading
 
 
 def swap_chars(s, i_1, i_2):
@@ -319,3 +320,24 @@ def conflicting_entries(dict_1, dict_2):
 def calculate_mi(corr):
     """Calculate mutual information from correlation coefficient."""
     return -0.5 * np.log(1 - corr**2)
+
+class timeout(object):
+    """Context manager for a timeout using threading module.
+    args:
+        timeout_duration: float, number of seconds to wait before timeout is triggered
+        exception_message: string, message to put in the exception
+    """
+    def __init__(self, timeout_duration, exception_message='Timeout'):
+        self.timeout_duration = timeout_duration
+        self.exception_message = exception_message
+
+    def __enter__(self):
+        self.timer = threading.Timer(self.timeout_duration, self.timeout_handler)
+        self.timer.start()
+        return self.timer
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.timer.cancel()
+
+    def timeout_handler(self):
+        raise TimeoutError(self.exception_message)

--- a/idtxl/multivariate_pid.py
+++ b/idtxl/multivariate_pid.py
@@ -8,7 +8,7 @@ Note:
 """
 import numpy as np
 from .single_process_analysis import SingleProcessAnalysis
-from .estimator import find_estimator
+from .estimator import get_estimator
 from .results import ResultsMultivariatePID
 
 
@@ -214,11 +214,8 @@ class MultivariatePID(SingleProcessAnalysis):
     def _initialise(self, settings, data, target, sources):
         """Check input, set initial or default values for analysis settings."""
         # Check requested PID estimator.
-        try:
-            EstimatorClass = find_estimator(settings['pid_estimator'])
-        except KeyError:
-            raise RuntimeError('Estimator was not specified!')
-        self._pid_estimator = EstimatorClass(settings)
+        assert 'pid_estimator' in settings, 'Estimator was not specified!'
+        self._pid_estimator = get_estimator(settings['pid_estimator'], settings)
 
         self.settings = settings.copy()
         self.settings.setdefault('lags_pid', [1 for i in range(len(sources))])

--- a/idtxl/network_analysis.py
+++ b/idtxl/network_analysis.py
@@ -8,7 +8,7 @@ import ast
 import copy as cp
 import itertools as it
 import numpy as np
-from .estimator import find_estimator
+from .estimator import get_estimator
 from . import idtxl_utils as utils
 from . import idtxl_io as io
 
@@ -202,17 +202,15 @@ class NetworkAnalysis():
         # average estimator. Internally, the average estimator is used for
         # building the non-uniform embedding, etc. The local estimator is used
         # to estimate single-link MI/TE or single-process AIS in the end.
-        try:
-            EstimatorClass = find_estimator(self.settings['cmi_estimator'])
-        except KeyError:
-            raise RuntimeError('Please provide an estimator class or name!')
+        assert 'cmi_estimator' in self.settings, 'Estimator was not specified!'
+
         if self.settings['local_values']:
             self.settings['local_values'] = False
-            self._cmi_estimator = EstimatorClass(self.settings)
+            self._cmi_estimator = get_estimator(self.settings['cmi_estimator'], self.settings)
             self.settings['local_values'] = True
-            self._cmi_estimator_local = EstimatorClass(self.settings)
+            self._cmi_estimator_local = get_estimator(self.settings['cmi_estimator'], self.settings)
         else:
-            self._cmi_estimator = EstimatorClass(self.settings)
+            self._cmi_estimator = get_estimator(self.settings['cmi_estimator'], self.settings)
 
     def _separate_realisations(self, idx_full, idx_single):
         """Separate single index realisations from a set of realisations.

--- a/idtxl/network_analysis.py
+++ b/idtxl/network_analysis.py
@@ -499,16 +499,16 @@ class NetworkAnalysis():
 
             if self.settings['local_values']:
                 local_values = self._cmi_estimator_local.estimate(
-                    current_value_realisations,
-                    source_realisations,
-                    conditional_realisations)
+                    var1=current_value_realisations,
+                    var2=source_realisations,
+                    conditional=conditional_realisations)
                 links[i] = local_values.reshape(
                     max(replication_ind) + 1, sum(replication_ind == 0)).T
             else:
                 links[i] = self._cmi_estimator.estimate(
-                    current_value_realisations,
-                    source_realisations,
-                    conditional_realisations)
+                    var1=current_value_realisations,
+                    var2=source_realisations,
+                    conditional=conditional_realisations)
 
         return links
 

--- a/idtxl/network_comparison.py
+++ b/idtxl/network_comparison.py
@@ -2,7 +2,7 @@
 import copy as cp
 import numpy as np
 from scipy.special import binom
-from .estimator import find_estimator
+from .estimator import get_estimator
 from . import stats
 from . import idtxl_utils as utils
 from .network_analysis import NetworkAnalysis
@@ -941,11 +941,8 @@ class NetworkComparison(NetworkAnalysis):
                            'or "independent".')
 
         # Add CMI estimator to class.
-        try:
-            EstimatorClass = find_estimator(settings['cmi_estimator'])
-        except KeyError:
-            raise KeyError('Please provide an estimator class or name!')
-        self._cmi_estimator = EstimatorClass(settings)
+        assert 'cmi_estimator' in settings, 'Estimator was not specified!'
+        self._cmi_estimator = get_estimator(settings['cmi_estimator'], settings)
 
         if 'local_values' in settings and settings['local_values']:
             raise RuntimeError('Can''t run network comparison on local values.')

--- a/test/performancetest_lorenz_2.py
+++ b/test/performancetest_lorenz_2.py
@@ -1,0 +1,65 @@
+import os
+import time
+import argparse
+import numpy as np
+from idtxl.multivariate_te import MultivariateTE
+from idtxl.data import Data
+
+"""
+This script uses the Lorenz 2 example to test the runtime scaling using multiprocessing and mpi.
+"""
+
+def profile_lorenz_2(n_java_threads, multiprocessing, n_processes, mpi, n_workers):
+    
+    assert multiprocessing or n_processes == 1, 'n_processes must be 1 if multithreading is disabled'
+
+    start_time = time.perf_counter()
+    # load simulated data from 2 coupled Lorenz systems 1->2, u = 45 ms
+    d = np.load(os.path.join(os.path.dirname(__file__),
+            'data/lorenz_2_exampledata.npy'))
+    data = Data()
+    data.set_data(d[:, :, 0:10], 'psr')
+    settings = {
+        'cmi_estimator':  'JidtKraskovCMI',
+        'max_lag_sources': 50,
+        'min_lag_sources': 40,
+        'max_lag_target': 30,
+        'tau_sources': 1,
+        'tau_target': 3,
+        'n_perm_max_stat': 200,
+        'n_perm_min_stat': 200,
+        'n_perm_omnibus': 500,
+        'n_perm_max_seq': 500,
+        'num_threads': n_java_threads,
+        'multiprocessing': multiprocessing,
+        'n_processes': n_processes,
+        'MPI': mpi,
+        'max_workers': n_workers,
+        }
+    lorenz_analysis = MultivariateTE()
+    _ = lorenz_analysis.analyse_single_target(settings, data, 0)
+    runtime = time.perf_counter() - start_time
+    
+    print(f'Lorenz 2 with {n_java_threads} Java threads and {n_processes} Python processes ({multiprocessing=}) took {runtime:.2f} seconds')
+
+    # Create results file if it doesn't exist
+    if not os.path.exists('performancetest_lorenz_2_runtimes.csv'):
+        with open('performancetest_lorenz_2_runtimes.csv', 'w') as f:
+            f.write('n_java_threads,multiprocessing,n_processes,mpi,max_workers,runtime\n')
+
+    # Append runtime to file
+    with open('performancetest_lorenz_2_runtimes.csv', 'a') as f:
+        f.write(f'{n_java_threads},{multiprocessing},{n_processes},{mpi},{n_workers},{runtime}\n')
+
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument('--n_java_threads', type=int, default=1)
+    argparser.add_argument('--multiprocessing', type=bool, default=False)
+    argparser.add_argument('--n_processes', type=int, default=1)
+    argparser.add_argument('--mpi', type=bool, default=False)
+    argparser.add_argument('--n_workers', type=int, default=1)
+
+    args = argparser.parse_args()
+    print(f'Running Lorenz 2 with {args.n_java_threads} Java threads and {args.n_processes} Python processes (multiprocessing={args.multiprocessing}), on {args.n_workers} workers (MPI={args.mpi}))')
+    profile_lorenz_2(args.n_java_threads, args.multiprocessing, args.n_processes, args.mpi, args.n_workers)
+

--- a/test/performancetest_lorenz_2_mpi_slurm.sh
+++ b/test/performancetest_lorenz_2_mpi_slurm.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# performancetest_lorenz_2.py with several different settings on a SLURM batch system.
+# Submit using command "sbatch".
+#
+#SBATCH -A cidbn
+#SBATCH -p cidbn
+#SBATCH --job-name=te_mp
+#SBATCH --output=performancetest_lorenz_2_mpi_%A.txt
+#SBATCH --time=24:00:00
+#SBATCH --ntasks=64
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=128gb
+#SBATCH --exclusive
+
+cd /usr/users/$USER/IDTxl
+
+export PYTHONPATH=/usr/users/$USER/IDTxl
+export JAVA_HOME=/usr/users/$USER/jdk-16.0.1
+
+source ~/.bashrc
+conda activate idtxl
+
+date
+
+# Run tests with a single java thread
+for n_workers in 64 32 16 8 4 2 1
+do
+    mpirun -n $n_workers python -m mpi4py.futures test/performancetest_lorenz_2.py --n_java_threads=1 --mpi=1 --n_workers=$n_workers
+    wait
+    date
+done
+

--- a/test/test_checkpointing.py
+++ b/test/test_checkpointing.py
@@ -1,6 +1,7 @@
 """Provide unit tests for IDTxl checkpointing."""
 import os
 import numpy as np
+import pytest
 from idtxl.multivariate_te import MultivariateTE
 from idtxl.data import Data
 from idtxl.idtxl_utils import calculate_mi
@@ -16,6 +17,8 @@ N_SAMPLES = 1000
 SEED = 0
 GAUSS_COV = 0.4
 DELAY = 1
+
+global_settings = {'MPI': True}
 
 
 def _clear_ckp(filename):
@@ -42,21 +45,27 @@ def test_checkpoint_defaults():
                 'max_lag_sources': 3,
                 'min_lag_sources': 2,
                 'verbose': True,
-                'write_ckp': True}
+                'write_ckp': True,
+                **global_settings}
     sources = [0, 1]
     targets = [3]
     network_analysis = MultivariateTE()
-    network_analysis._set_checkpointing_defaults(settings, data, sources, targets)
+    network_analysis._set_checkpointing_defaults(
+        settings, data, sources, targets)
     ckp_file = os.path.join(os.path.dirname(__file__), 'idtxl_checkpoint')
-    assert os.path.isfile(f'{ckp_file}.ckp'), 'Did not write default checkpoint file'
-    assert os.path.isfile(f'{ckp_file}.dat'), 'Did not write default checkpoint data'
-    assert os.path.isfile(f'{ckp_file}.json'), 'Did not write default checkpoint settings'
+    assert os.path.isfile(
+        f'{ckp_file}.ckp'), 'Did not write default checkpoint file'
+    assert os.path.isfile(
+        f'{ckp_file}.dat'), 'Did not write default checkpoint data'
+    assert os.path.isfile(
+        f'{ckp_file}.json'), 'Did not write default checkpoint settings'
 
     # Check if
     data_res, settings_res, targets_res, sources_res = network_analysis.resume_checkpoint(
         ckp_file)
     for k in settings:
-        assert settings[k] == settings_res[k], f'Unequal entries in settings: key {k}'
+        assert settings[k] == settings_res[
+            k], f'Unequal entries in settings: key {k}'
     assert sources == sources_res, 'Sources not the same'
     assert targets == targets_res, 'Targets not the same'
 
@@ -77,7 +86,8 @@ def test_checkpoint_resume():
                 'max_lag_sources': 3,
                 'min_lag_sources': 2,
                 'write_ckp': True,
-                'filename_ckp': filename_ckp}
+                'filename_ckp': filename_ckp,
+                **global_settings}
 
     # Manually create checkpoint files for two targets.
     # Note that variables are added as absolute time indices and not lags wrt.
@@ -127,7 +137,8 @@ def test_checkpoint_copy():
                 'max_lag_sources': 3,
                 'min_lag_sources': 2,
                 'write_ckp': True,
-                'filename_ckp': filename_ckp}
+                'filename_ckp': filename_ckp,
+                **global_settings}
 
     # Manually create checkpoint files for two targets.
     # Note that variables are added as absolute time indices and not lags wrt.
@@ -169,7 +180,8 @@ def test_JidtGaussianCMI_MMI_checkpoint():
     settings1 = {'cmi_estimator': 'JidtGaussianCMI',
                  'max_lag_sources': 3,
                  'min_lag_sources': 2,
-                 'noise_level': 0
+                 'noise_level': 0,
+                 **global_settings
                  }
 
     # Settings with checkpointing.
@@ -178,7 +190,9 @@ def test_JidtGaussianCMI_MMI_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp1}
+                 'filename_ckp': filename_ckp1,
+                 **global_settings
+                 }
 
     # Settings resuming from checkpoint.
     settings3 = {'cmi_estimator': 'JidtGaussianCMI',
@@ -186,7 +200,9 @@ def test_JidtGaussianCMI_MMI_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp2}
+                 'filename_ckp': filename_ckp2,
+                 **global_settings
+                 }
 
     # Setting sources and targets for the analysis
     sources = [0, 1]
@@ -255,7 +271,8 @@ def test_JidtGaussianCMI_MMI_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -446,7 +463,8 @@ def test_JidtDiscreteCMI_MMI_checkpoint():
         'n_perm_max_seq': 30,
         'min_lag_sources': DELAY,
         'max_lag_sources': DELAY,
-        'max_lag_target': 1}
+        'max_lag_target': 1,
+        **global_settings}
 
     settings2 = settings1.copy()
     settings2['write_ckp'] = True
@@ -518,7 +536,8 @@ def test_JidtDiscreteCMI_MMI_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -565,7 +584,8 @@ def test_JidtGaussianCMI_MTE_checkpoint():
                  'n_perm_omnibus': N_PERM,
                  'max_lag_sources': 3,
                  'min_lag_sources': 2,
-                 'noise_level': 0
+                 'noise_level': 0,
+                 **global_settings
                  }
 
     # Settings with checkpointing.
@@ -574,7 +594,9 @@ def test_JidtGaussianCMI_MTE_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp1}
+                 'filename_ckp': filename_ckp1,
+                 **global_settings
+                 }
 
     # Settings resuming from checkpoint.
     settings3 = {'cmi_estimator': 'JidtGaussianCMI',
@@ -582,7 +604,8 @@ def test_JidtGaussianCMI_MTE_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp2}
+                 'filename_ckp': filename_ckp2,
+                 **global_settings}
 
     # Setting sources and targets for the analysis
     sources = [0, 1]
@@ -650,7 +673,8 @@ def test_JidtGaussianCMI_MTE_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -822,10 +846,10 @@ def test_JidtDiscreteCMI_MTE_checkpoint():
     """Test multivariate TE estimation from discrete data."""
     # Generate Gaussian test data
     data = _get_discrete_gauss_data(covariance=GAUSS_COV,
-                                n=N_SAMPLES*10,
-                                delay=DELAY,
-                                normalise=False,
-                                seed=SEED)
+                                    n=N_SAMPLES*10,
+                                    delay=DELAY,
+                                    normalise=False,
+                                    seed=SEED)
 
     settings1 = {
         'cmi_estimator': 'JidtDiscreteCMI',
@@ -836,7 +860,9 @@ def test_JidtDiscreteCMI_MTE_checkpoint():
         'n_perm_max_seq': 30,
         'min_lag_sources': DELAY,
         'max_lag_sources': DELAY,
-        'max_lag_target': 1}
+        'max_lag_target': 1,
+        **global_settings
+    }
 
     settings2 = settings1.copy()
     settings2['write_ckp'] = True
@@ -913,7 +939,8 @@ def test_JidtDiscreteCMI_MTE_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -960,7 +987,8 @@ def test_JidtGaussianCMI_BTE_checkpoint():
                  'n_perm_omnibus': N_PERM,
                  'max_lag_sources': 3,
                  'min_lag_sources': 2,
-                 'noise_level': 0
+                 'noise_level': 0,
+                 **global_settings
                  }
 
     # Settings with checkpointing.
@@ -1040,7 +1068,8 @@ def test_JidtGaussianCMI_BTE_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -1199,10 +1228,10 @@ def test_JidtDiscreteCMI_BTE_checkpoint():
     """Test multivariate TE estimation from discrete data."""
     # Generate Gaussian test data
     data = _get_discrete_gauss_data(covariance=GAUSS_COV,
-                                n=N_SAMPLES*10,
-                                delay=DELAY,
-                                normalise=False,
-                                seed=SEED)
+                                    n=N_SAMPLES*10,
+                                    delay=DELAY,
+                                    normalise=False,
+                                    seed=SEED)
 
     settings1 = {
         'cmi_estimator': 'JidtDiscreteCMI',
@@ -1213,7 +1242,9 @@ def test_JidtDiscreteCMI_BTE_checkpoint():
         'n_perm_max_seq': 30,
         'min_lag_sources': DELAY,
         'max_lag_sources': DELAY,
-        'max_lag_target': 1}
+        'max_lag_target': 1,
+        **global_settings
+    }
 
     settings2 = settings1.copy()
     settings2['write_ckp'] = True
@@ -1290,7 +1321,8 @@ def test_JidtDiscreteCMI_BTE_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -1333,7 +1365,8 @@ def test_JidtGaussianCMI_BMI_checkpoint():
     settings1 = {'cmi_estimator': 'JidtGaussianCMI',
                  'max_lag_sources': 3,
                  'min_lag_sources': 2,
-                 'noise_level': 0
+                 'noise_level': 0,
+                 **global_settings
                  }
 
     # Settings with checkpointing.
@@ -1342,7 +1375,8 @@ def test_JidtGaussianCMI_BMI_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp1}
+                 'filename_ckp': filename_ckp1,
+                 **global_settings}
 
     # Settings resuming from checkpoint.
     settings3 = {'cmi_estimator': 'JidtGaussianCMI',
@@ -1350,7 +1384,8 @@ def test_JidtGaussianCMI_BMI_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp2}
+                 'filename_ckp': filename_ckp2,
+                 **global_settings}
 
     # Setting sources and targets for the analysis
     sources = [0, 1]
@@ -1419,7 +1454,8 @@ def test_JidtGaussianCMI_BMI_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -1590,10 +1626,10 @@ def test_JidtDiscreteCMI_BMI_checkpoint():
 
     # Generate Gaussian test data
     data = _get_discrete_gauss_data(covariance=GAUSS_COV,
-                                n=N_SAMPLES*10,
-                                delay=DELAY,
-                                normalise=False,
-                                seed=SEED)
+                                    n=N_SAMPLES*10,
+                                    delay=DELAY,
+                                    normalise=False,
+                                    seed=SEED)
 
     settings1 = {
         'cmi_estimator': 'JidtDiscreteCMI',
@@ -1604,7 +1640,9 @@ def test_JidtDiscreteCMI_BMI_checkpoint():
         'n_perm_max_seq': 30,
         'min_lag_sources': DELAY,
         'max_lag_sources': DELAY,
-        'max_lag_target': 1}
+        'max_lag_target': 1,
+        **global_settings
+    }
 
     settings2 = settings1.copy()
     settings2['write_ckp'] = True
@@ -1682,7 +1720,145 @@ def test_JidtDiscreteCMI_BMI_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
+
+    cmp1 = list(set(result1).intersection(result2))
+    cmp2 = list(set(result1).intersection(result3))
+    cmp3 = list(set(result1).intersection(result4))
+    len1 = len(result1)
+    assert len(cmp1) == len1 and len(cmp2) == len1 and len(cmp3) != len1, (
+        "Discrete MultivariateMI Running with checkpoints does not give the expected results")
+
+    print("Final")
+    print("Elements of comparison between result 1 and 2")
+    print(cmp1)
+    print("Elements of comparison between result 1 and 3")
+    print(cmp2)
+    print("Elements of comparison between result 1 and 4")
+    print(cmp3)
+
+    _clear_ckp(filename_ckp1)
+    _clear_ckp(filename_ckp2)
+
+
+@pytest.mark.mpi
+def test_MPI_checkpoint():
+    return
+    """ run test without checkpointing, with checkpointing without resume and checkpointing with resume to compare the results"""
+    filename_ckp1 = os.path.join(
+        os.path.dirname(__file__), 'data', 'run_checkpoint')
+    filename_ckp2 = os.path.join(
+        os.path.dirname(__file__), 'data', 'resume_checkpoint')
+
+    """Test running analysis without any checkpoint setting."""
+    # Generate test data
+    data = Data(seed=SEED)
+    data.generate_mute_data(n_samples=N_SAMPLES, n_replications=1)
+
+    # Initialise analysis object and define settings
+    network_analysis1 = MultivariateMI()
+    network_analysis2 = MultivariateMI()
+    network_analysis3 = MultivariateMI()
+    network_analysis4 = MultivariateMI()
+
+    # Settings without checkpointing.
+    settings1 = {'cmi_estimator': 'JidtGaussianCMI',
+                 'max_lag_sources': 3,
+                 'min_lag_sources': 2,
+                 'noise_level': 0,
+                 'MPI': True
+                 }
+
+    # Settings with checkpointing.
+    settings2 = {'cmi_estimator': 'JidtGaussianCMI',
+                 'max_lag_sources': 3,
+                 'min_lag_sources': 2,
+                 'noise_level': 0,
+                 'write_ckp': True,
+                 'filename_ckp': filename_ckp1,
+                 'MPI': True
+                 }
+
+    # Settings resuming from checkpoint.
+    settings3 = {'cmi_estimator': 'JidtGaussianCMI',
+                 'max_lag_sources': 3,
+                 'min_lag_sources': 2,
+                 'noise_level': 0,
+                 'write_ckp': True,
+                 'filename_ckp': filename_ckp2,
+                 'MPI': True
+                 }
+
+    # Setting sources and targets for the analysis
+    sources = [0, 1]
+    targets = [2, 3]
+    targets2 = [3]
+
+    # Starting Analysis of the Network
+    # results of a network analysis without checkpointing
+    results1 = network_analysis1.analyse_network(
+        settings=settings1, data=data, targets=targets, sources=sources)
+
+    # results of a network analysis with checkpointing
+    results2 = network_analysis2.analyse_network(
+        settings=settings2, data=data, targets=targets, sources=sources)
+
+    # Creating a checkpoint similar to the above settings where the targets of
+    # of the first source have been already analyzed
+    with open(filename_ckp1 + ".ckp", "r+") as f:
+        tarsource = f.readlines()
+    tarsource = tarsource[8]
+    tarsource = (tarsource[:-1])
+
+    network_analysis3._set_checkpointing_defaults(
+        settings3, data, sources, targets)
+
+    with open(filename_ckp2 + ".ckp") as f:
+        lines = f.read().splitlines()
+    lines[8] = tarsource
+    with open(filename_ckp2 + ".ckp", 'w') as f:
+        f.write('\n'.join(lines))
+    print(lines)
+
+    # Resume analysis.
+    network_analysis_res = MultivariateMI()
+    data, settings, targets, sources = network_analysis_res.resume_checkpoint(
+        filename_ckp2)
+
+    # results of a network analysis resuming from checkpoint
+    results3 = network_analysis_res.analyse_network(
+        settings=settings3, data=data, targets=targets, sources=sources)
+
+    # results of a network analysis without checkpointing but other targets/sources
+    results4 = network_analysis4.analyse_network(
+        settings=settings1, data=data, targets=targets2, sources=sources)
+
+    adj_matrix1 = results1.get_adjacency_matrix(weights='binary', fdr=False)
+    adj_matrix2 = results2.get_adjacency_matrix(weights='binary', fdr=False)
+    adj_matrix3 = results3.get_adjacency_matrix(weights='binary', fdr=False)
+    adj_matrix4 = results4.get_adjacency_matrix(weights='binary', fdr=False)
+
+    result1 = adj_matrix1.get_edge_list()
+    result2 = adj_matrix2.get_edge_list()
+    result3 = adj_matrix3.get_edge_list()
+    result4 = adj_matrix4.get_edge_list()
+
+    print("Printing results:")
+    print("Result 1: without checkpoint")
+    print(result1)
+    print("Result 2: with checkpoint")
+    print(result2)
+    print("Result 3: resuming from checkpoint")
+    print(result3)
+    print("Result 4: without checkpoint and different targets and sources")
+    print(result4)
+
+    print("Comparing the results:")
+    assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
+    assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))

--- a/test/test_checkpointing_mpi.py
+++ b/test/test_checkpointing_mpi.py
@@ -1,6 +1,7 @@
 """Provide unit tests for IDTxl checkpointing."""
 import os
 import numpy as np
+import pytest
 from idtxl.multivariate_te import MultivariateTE
 from idtxl.data import Data
 from idtxl.idtxl_utils import calculate_mi
@@ -16,6 +17,8 @@ N_SAMPLES = 1000
 SEED = 0
 GAUSS_COV = 0.4
 DELAY = 1
+
+global_settings = {'MPI': True}
 
 
 def _clear_ckp(filename):
@@ -42,21 +45,27 @@ def test_checkpoint_defaults():
                 'max_lag_sources': 3,
                 'min_lag_sources': 2,
                 'verbose': True,
-                'write_ckp': True}
+                'write_ckp': True,
+                **global_settings}
     sources = [0, 1]
     targets = [3]
     network_analysis = MultivariateTE()
-    network_analysis._set_checkpointing_defaults(settings, data, sources, targets)
+    network_analysis._set_checkpointing_defaults(
+        settings, data, sources, targets)
     ckp_file = os.path.join(os.path.dirname(__file__), 'idtxl_checkpoint')
-    assert os.path.isfile(f'{ckp_file}.ckp'), 'Did not write default checkpoint file'
-    assert os.path.isfile(f'{ckp_file}.dat'), 'Did not write default checkpoint data'
-    assert os.path.isfile(f'{ckp_file}.json'), 'Did not write default checkpoint settings'
+    assert os.path.isfile(
+        f'{ckp_file}.ckp'), 'Did not write default checkpoint file'
+    assert os.path.isfile(
+        f'{ckp_file}.dat'), 'Did not write default checkpoint data'
+    assert os.path.isfile(
+        f'{ckp_file}.json'), 'Did not write default checkpoint settings'
 
     # Check if
     data_res, settings_res, targets_res, sources_res = network_analysis.resume_checkpoint(
         ckp_file)
     for k in settings:
-        assert settings[k] == settings_res[k], f'Unequal entries in settings: key {k}'
+        assert settings[k] == settings_res[
+            k], f'Unequal entries in settings: key {k}'
     assert sources == sources_res, 'Sources not the same'
     assert targets == targets_res, 'Targets not the same'
 
@@ -77,7 +86,8 @@ def test_checkpoint_resume():
                 'max_lag_sources': 3,
                 'min_lag_sources': 2,
                 'write_ckp': True,
-                'filename_ckp': filename_ckp}
+                'filename_ckp': filename_ckp,
+                **global_settings}
 
     # Manually create checkpoint files for two targets.
     # Note that variables are added as absolute time indices and not lags wrt.
@@ -127,7 +137,8 @@ def test_checkpoint_copy():
                 'max_lag_sources': 3,
                 'min_lag_sources': 2,
                 'write_ckp': True,
-                'filename_ckp': filename_ckp}
+                'filename_ckp': filename_ckp,
+                **global_settings}
 
     # Manually create checkpoint files for two targets.
     # Note that variables are added as absolute time indices and not lags wrt.
@@ -169,7 +180,8 @@ def test_JidtGaussianCMI_MMI_checkpoint():
     settings1 = {'cmi_estimator': 'JidtGaussianCMI',
                  'max_lag_sources': 3,
                  'min_lag_sources': 2,
-                 'noise_level': 0
+                 'noise_level': 0,
+                 **global_settings
                  }
 
     # Settings with checkpointing.
@@ -178,7 +190,9 @@ def test_JidtGaussianCMI_MMI_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp1}
+                 'filename_ckp': filename_ckp1,
+                 **global_settings
+                 }
 
     # Settings resuming from checkpoint.
     settings3 = {'cmi_estimator': 'JidtGaussianCMI',
@@ -186,7 +200,9 @@ def test_JidtGaussianCMI_MMI_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp2}
+                 'filename_ckp': filename_ckp2,
+                 **global_settings
+                 }
 
     # Setting sources and targets for the analysis
     sources = [0, 1]
@@ -255,7 +271,8 @@ def test_JidtGaussianCMI_MMI_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -446,7 +463,8 @@ def test_JidtDiscreteCMI_MMI_checkpoint():
         'n_perm_max_seq': 30,
         'min_lag_sources': DELAY,
         'max_lag_sources': DELAY,
-        'max_lag_target': 1}
+        'max_lag_target': 1,
+        **global_settings}
 
     settings2 = settings1.copy()
     settings2['write_ckp'] = True
@@ -518,7 +536,8 @@ def test_JidtDiscreteCMI_MMI_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -565,7 +584,8 @@ def test_JidtGaussianCMI_MTE_checkpoint():
                  'n_perm_omnibus': N_PERM,
                  'max_lag_sources': 3,
                  'min_lag_sources': 2,
-                 'noise_level': 0
+                 'noise_level': 0,
+                 **global_settings
                  }
 
     # Settings with checkpointing.
@@ -574,7 +594,9 @@ def test_JidtGaussianCMI_MTE_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp1}
+                 'filename_ckp': filename_ckp1,
+                 **global_settings
+                 }
 
     # Settings resuming from checkpoint.
     settings3 = {'cmi_estimator': 'JidtGaussianCMI',
@@ -582,7 +604,8 @@ def test_JidtGaussianCMI_MTE_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp2}
+                 'filename_ckp': filename_ckp2,
+                 **global_settings}
 
     # Setting sources and targets for the analysis
     sources = [0, 1]
@@ -650,7 +673,8 @@ def test_JidtGaussianCMI_MTE_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -822,10 +846,10 @@ def test_JidtDiscreteCMI_MTE_checkpoint():
     """Test multivariate TE estimation from discrete data."""
     # Generate Gaussian test data
     data = _get_discrete_gauss_data(covariance=GAUSS_COV,
-                                n=N_SAMPLES*10,
-                                delay=DELAY,
-                                normalise=False,
-                                seed=SEED)
+                                    n=N_SAMPLES*10,
+                                    delay=DELAY,
+                                    normalise=False,
+                                    seed=SEED)
 
     settings1 = {
         'cmi_estimator': 'JidtDiscreteCMI',
@@ -836,7 +860,9 @@ def test_JidtDiscreteCMI_MTE_checkpoint():
         'n_perm_max_seq': 30,
         'min_lag_sources': DELAY,
         'max_lag_sources': DELAY,
-        'max_lag_target': 1}
+        'max_lag_target': 1,
+        **global_settings
+    }
 
     settings2 = settings1.copy()
     settings2['write_ckp'] = True
@@ -913,7 +939,8 @@ def test_JidtDiscreteCMI_MTE_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -960,7 +987,8 @@ def test_JidtGaussianCMI_BTE_checkpoint():
                  'n_perm_omnibus': N_PERM,
                  'max_lag_sources': 3,
                  'min_lag_sources': 2,
-                 'noise_level': 0
+                 'noise_level': 0,
+                 **global_settings
                  }
 
     # Settings with checkpointing.
@@ -1040,7 +1068,8 @@ def test_JidtGaussianCMI_BTE_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -1199,10 +1228,10 @@ def test_JidtDiscreteCMI_BTE_checkpoint():
     """Test multivariate TE estimation from discrete data."""
     # Generate Gaussian test data
     data = _get_discrete_gauss_data(covariance=GAUSS_COV,
-                                n=N_SAMPLES*10,
-                                delay=DELAY,
-                                normalise=False,
-                                seed=SEED)
+                                    n=N_SAMPLES*10,
+                                    delay=DELAY,
+                                    normalise=False,
+                                    seed=SEED)
 
     settings1 = {
         'cmi_estimator': 'JidtDiscreteCMI',
@@ -1213,7 +1242,9 @@ def test_JidtDiscreteCMI_BTE_checkpoint():
         'n_perm_max_seq': 30,
         'min_lag_sources': DELAY,
         'max_lag_sources': DELAY,
-        'max_lag_target': 1}
+        'max_lag_target': 1,
+        **global_settings
+    }
 
     settings2 = settings1.copy()
     settings2['write_ckp'] = True
@@ -1290,7 +1321,8 @@ def test_JidtDiscreteCMI_BTE_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -1333,7 +1365,8 @@ def test_JidtGaussianCMI_BMI_checkpoint():
     settings1 = {'cmi_estimator': 'JidtGaussianCMI',
                  'max_lag_sources': 3,
                  'min_lag_sources': 2,
-                 'noise_level': 0
+                 'noise_level': 0,
+                 **global_settings
                  }
 
     # Settings with checkpointing.
@@ -1342,7 +1375,8 @@ def test_JidtGaussianCMI_BMI_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp1}
+                 'filename_ckp': filename_ckp1,
+                 **global_settings}
 
     # Settings resuming from checkpoint.
     settings3 = {'cmi_estimator': 'JidtGaussianCMI',
@@ -1350,7 +1384,8 @@ def test_JidtGaussianCMI_BMI_checkpoint():
                  'min_lag_sources': 2,
                  'noise_level': 0,
                  'write_ckp': True,
-                 'filename_ckp': filename_ckp2}
+                 'filename_ckp': filename_ckp2,
+                 **global_settings}
 
     # Setting sources and targets for the analysis
     sources = [0, 1]
@@ -1419,7 +1454,8 @@ def test_JidtGaussianCMI_BMI_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))
@@ -1590,10 +1626,10 @@ def test_JidtDiscreteCMI_BMI_checkpoint():
 
     # Generate Gaussian test data
     data = _get_discrete_gauss_data(covariance=GAUSS_COV,
-                                n=N_SAMPLES*10,
-                                delay=DELAY,
-                                normalise=False,
-                                seed=SEED)
+                                    n=N_SAMPLES*10,
+                                    delay=DELAY,
+                                    normalise=False,
+                                    seed=SEED)
 
     settings1 = {
         'cmi_estimator': 'JidtDiscreteCMI',
@@ -1604,7 +1640,9 @@ def test_JidtDiscreteCMI_BMI_checkpoint():
         'n_perm_max_seq': 30,
         'min_lag_sources': DELAY,
         'max_lag_sources': DELAY,
-        'max_lag_target': 1}
+        'max_lag_target': 1,
+        **global_settings
+    }
 
     settings2 = settings1.copy()
     settings2['write_ckp'] = True
@@ -1682,7 +1720,145 @@ def test_JidtDiscreteCMI_BMI_checkpoint():
     print("Comparing the results:")
     assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
     assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
-    assert not np.array_equal(result1, result4), 'Result 1 and 4 equal, expected to be different!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
+
+    cmp1 = list(set(result1).intersection(result2))
+    cmp2 = list(set(result1).intersection(result3))
+    cmp3 = list(set(result1).intersection(result4))
+    len1 = len(result1)
+    assert len(cmp1) == len1 and len(cmp2) == len1 and len(cmp3) != len1, (
+        "Discrete MultivariateMI Running with checkpoints does not give the expected results")
+
+    print("Final")
+    print("Elements of comparison between result 1 and 2")
+    print(cmp1)
+    print("Elements of comparison between result 1 and 3")
+    print(cmp2)
+    print("Elements of comparison between result 1 and 4")
+    print(cmp3)
+
+    _clear_ckp(filename_ckp1)
+    _clear_ckp(filename_ckp2)
+
+
+@pytest.mark.mpi
+def test_MPI_checkpoint():
+    return
+    """ run test without checkpointing, with checkpointing without resume and checkpointing with resume to compare the results"""
+    filename_ckp1 = os.path.join(
+        os.path.dirname(__file__), 'data', 'run_checkpoint')
+    filename_ckp2 = os.path.join(
+        os.path.dirname(__file__), 'data', 'resume_checkpoint')
+
+    """Test running analysis without any checkpoint setting."""
+    # Generate test data
+    data = Data(seed=SEED)
+    data.generate_mute_data(n_samples=N_SAMPLES, n_replications=1)
+
+    # Initialise analysis object and define settings
+    network_analysis1 = MultivariateMI()
+    network_analysis2 = MultivariateMI()
+    network_analysis3 = MultivariateMI()
+    network_analysis4 = MultivariateMI()
+
+    # Settings without checkpointing.
+    settings1 = {'cmi_estimator': 'JidtGaussianCMI',
+                 'max_lag_sources': 3,
+                 'min_lag_sources': 2,
+                 'noise_level': 0,
+                 'MPI': True
+                 }
+
+    # Settings with checkpointing.
+    settings2 = {'cmi_estimator': 'JidtGaussianCMI',
+                 'max_lag_sources': 3,
+                 'min_lag_sources': 2,
+                 'noise_level': 0,
+                 'write_ckp': True,
+                 'filename_ckp': filename_ckp1,
+                 'MPI': True
+                 }
+
+    # Settings resuming from checkpoint.
+    settings3 = {'cmi_estimator': 'JidtGaussianCMI',
+                 'max_lag_sources': 3,
+                 'min_lag_sources': 2,
+                 'noise_level': 0,
+                 'write_ckp': True,
+                 'filename_ckp': filename_ckp2,
+                 'MPI': True
+                 }
+
+    # Setting sources and targets for the analysis
+    sources = [0, 1]
+    targets = [2, 3]
+    targets2 = [3]
+
+    # Starting Analysis of the Network
+    # results of a network analysis without checkpointing
+    results1 = network_analysis1.analyse_network(
+        settings=settings1, data=data, targets=targets, sources=sources)
+
+    # results of a network analysis with checkpointing
+    results2 = network_analysis2.analyse_network(
+        settings=settings2, data=data, targets=targets, sources=sources)
+
+    # Creating a checkpoint similar to the above settings where the targets of
+    # of the first source have been already analyzed
+    with open(filename_ckp1 + ".ckp", "r+") as f:
+        tarsource = f.readlines()
+    tarsource = tarsource[8]
+    tarsource = (tarsource[:-1])
+
+    network_analysis3._set_checkpointing_defaults(
+        settings3, data, sources, targets)
+
+    with open(filename_ckp2 + ".ckp") as f:
+        lines = f.read().splitlines()
+    lines[8] = tarsource
+    with open(filename_ckp2 + ".ckp", 'w') as f:
+        f.write('\n'.join(lines))
+    print(lines)
+
+    # Resume analysis.
+    network_analysis_res = MultivariateMI()
+    data, settings, targets, sources = network_analysis_res.resume_checkpoint(
+        filename_ckp2)
+
+    # results of a network analysis resuming from checkpoint
+    results3 = network_analysis_res.analyse_network(
+        settings=settings3, data=data, targets=targets, sources=sources)
+
+    # results of a network analysis without checkpointing but other targets/sources
+    results4 = network_analysis4.analyse_network(
+        settings=settings1, data=data, targets=targets2, sources=sources)
+
+    adj_matrix1 = results1.get_adjacency_matrix(weights='binary', fdr=False)
+    adj_matrix2 = results2.get_adjacency_matrix(weights='binary', fdr=False)
+    adj_matrix3 = results3.get_adjacency_matrix(weights='binary', fdr=False)
+    adj_matrix4 = results4.get_adjacency_matrix(weights='binary', fdr=False)
+
+    result1 = adj_matrix1.get_edge_list()
+    result2 = adj_matrix2.get_edge_list()
+    result3 = adj_matrix3.get_edge_list()
+    result4 = adj_matrix4.get_edge_list()
+
+    print("Printing results:")
+    print("Result 1: without checkpoint")
+    print(result1)
+    print("Result 2: with checkpoint")
+    print(result2)
+    print("Result 3: resuming from checkpoint")
+    print(result3)
+    print("Result 4: without checkpoint and different targets and sources")
+    print(result4)
+
+    print("Comparing the results:")
+    assert np.array_equal(result1, result2), 'Result 1 and 2 not equal!'
+    assert np.array_equal(result1, result3), 'Result 1 and 3 not equal!'
+    assert not np.array_equal(
+        result1, result4), 'Result 1 and 4 equal, expected to be different!'
 
     cmp1 = list(set(result1).intersection(result2))
     cmp2 = list(set(result1).intersection(result3))

--- a/test/test_estimator.py
+++ b/test/test_estimator.py
@@ -7,7 +7,7 @@ This functionality is handled by the estimator class and tested here.
 import inspect
 import pytest
 import numpy as np
-from idtxl.estimator import find_estimator
+from idtxl.estimator import _find_estimator
 from idtxl.multivariate_te import MultivariateTE
 from idtxl.estimators_jidt import JidtKraskovMI
 from test_estimators_jidt import jpype_missing, _get_gauss_data
@@ -17,18 +17,18 @@ def test_find_estimator():
     """Test dynamic loading of classes."""
 
     # Test if a class is returned.
-    e = find_estimator('JidtKraskovMI')
+    e = _find_estimator('JidtKraskovMI')
     assert inspect.isclass(e)
-    f = find_estimator(e)
+    f = _find_estimator(e)
     assert inspect.isclass(f)
 
     # Try loading non-existent estimator
     with pytest.raises(RuntimeError):
-        find_estimator('test')
+        _find_estimator('test')
 
     # Try using a class without an estimate method
     with pytest.raises(RuntimeError):
-        find_estimator(MultivariateTE)
+        _find_estimator(MultivariateTE)
 
 
 @jpype_missing

--- a/test/test_mpi.py
+++ b/test/test_mpi.py
@@ -10,7 +10,7 @@ import pytest
 from mpi4py import MPI
 from idtxl.estimator import get_estimator
 from idtxl.estimators_jidt import JidtKraskov
-from idtxl.estimators_mpi import MPIEstimator
+from idtxl.estimators_mpi import MPIEstimator, _get_worker_estimator
 from idtxl.multivariate_te import MultivariateTE
 from idtxl.data import Data
 import time
@@ -37,8 +37,7 @@ def test_mpi_estimator_creation():
         settings['cmi_estimator'], settings)
 
     assert isinstance(estimator, MPIEstimator), 'MPIEstimator has wrong class!'
-    assert isinstance(estimator._estimator,
-                      JidtKraskov), 'MPIEstimator wraps the wrong estimator!'
+    assert isinstance(_get_worker_estimator(estimator._id, None, None), JidtKraskov), 'MPIEstimator wraps the wrong estimator!'
 
 
 @pytest.mark.mpi

--- a/test/test_mpi.py
+++ b/test/test_mpi.py
@@ -1,0 +1,190 @@
+"""
+Test the MPI parallelization.
+
+To run these tests, use:
+
+mpirun -n 8 python -m mpi4py.futures -m pytest --with-mpi test/test_mpi.py
+"""
+from idtxl.estimators_mpi import MPIEstimator
+import pytest
+from mpi4py import MPI
+from idtxl.estimator import get_estimator
+from idtxl.estimators_jidt import JidtKraskov
+from idtxl.estimators_mpi import MPIEstimator
+from idtxl.multivariate_te import MultivariateTE
+from idtxl.data import Data
+import time
+import numpy as np
+import os
+
+N_PERM = 21  # this no. permutations is usually sufficient to find links in the MUTE data
+N_SAMPLES = 1000
+SEED = 0
+MAX_WORKERS = 4
+
+
+def test_mpi_estimator_creation():
+    """Check whether a JIDT Kraskov estimator with MPI is correctly initialized"""
+
+    settings = {'cmi_estimator': 'JidtKraskovCMI',
+                'max_lag_sources': 5,
+                'min_lag_sources': 1,
+                'MPI': True,
+                'max_workers': MAX_WORKERS
+                }
+
+    estimator = get_estimator(
+        settings['cmi_estimator'], settings)
+
+    assert isinstance(estimator, MPIEstimator), 'MPIEstimator has wrong class!'
+    assert isinstance(estimator._estimator,
+                      JidtKraskov), 'MPIEstimator wraps the wrong estimator!'
+
+
+@pytest.mark.mpi
+def test_mpi_installation():
+    comm = MPI.COMM_WORLD
+    size = comm.Get_size()
+    rank = comm.Get_rank()
+
+    assert rank == 0, 'Test not run on main rank'
+    assert size >= MAX_WORKERS + \
+        1, f'Insufficient MPI workers for testing. Please have at least {MAX_WORKERS + 1} threads available.'
+
+
+def _wait_and_get_rank(arg):
+    time.sleep(3)
+    return MPI.COMM_WORLD.Get_rank()
+
+
+@pytest.mark.mpi
+@pytest.mark.xfail
+def test_mpi_ranks():
+    """
+    Test whether the number of workers is restricted to max_workers, even if more threads are available.
+    Currently, this does not work, which is most likely a bug in mpi4py.
+    """
+    settings = {'cmi_estimator': 'JidtKraskovCMI',
+                'max_lag_sources': 5,
+                'min_lag_sources': 1,
+                'MPI': True,
+                'max_workers': MAX_WORKERS
+                }
+
+    estimator = get_estimator(
+        settings['cmi_estimator'], settings)
+
+    ranks = list(estimator._executor.map(
+        _wait_and_get_rank, range(2 * MAX_WORKERS)))
+    print(ranks)
+
+    assert np.array_equal(np.unique(ranks), np.arange(
+        1, MAX_WORKERS+1)), 'The actual number of worker ranks is not equal to MAX_RANKS.'
+
+
+@pytest.mark.mpi
+def test_mpi_JidtGaussianCMI_MTE():
+    """Compute Multivariate transfer entropy for test data with and without MPI and compare results
+    """
+
+    # a) Generate test data
+    data = Data()
+    data.generate_mute_data(n_samples=1000, n_replications=5)
+
+    # b) Initialise analysis object with and without MPI
+    network_analysis1 = MultivariateTE()
+    settings1 = {'cmi_estimator': 'JidtGaussianCMI',
+                 'max_lag_sources': 5,
+                 'min_lag_sources': 1,
+                 'MPI': True,
+                 'max_workers': MAX_WORKERS
+                 }
+    network_analysis2 = MultivariateTE()
+    settings2 = {'cmi_estimator': 'JidtGaussianCMI',
+                 'max_lag_sources': 5,
+                 'min_lag_sources': 1,
+                 }
+
+    # c) Run analysis
+    print('Running MTE analysis with MPI')
+    results1 = network_analysis1.analyse_network(settings=settings1, data=data)
+    print('Running MTE analysis without MPI')
+    results2 = network_analysis2.analyse_network(settings=settings2, data=data)
+
+    # d) Compare results
+    adj_matrix1 = results1.get_adjacency_matrix(weights='binary', fdr=False)
+    adj_matrix2 = results2.get_adjacency_matrix(weights='binary', fdr=False)
+
+    result1 = adj_matrix1.get_edge_list()
+    result2 = adj_matrix2.get_edge_list()
+
+    print(f'{result1=}')
+    print(f'{result2=}')
+
+    assert np.array_equal(
+        result1, result2), 'Results with and without MPI differ!'
+
+
+def _clear_ckp(filename):
+    # Delete created checkpoint from disk.
+    os.remove(f'{filename}.ckp')
+    try:
+        os.remove(f'{filename}.ckp.old')
+    except FileNotFoundError:
+        # If algorithm ran for only one iteration, no old checkpoint exists.
+        print(f'No file {filename}.ckp.old')
+    os.remove(f'{filename}.dat')
+    os.remove(f'{filename}.json')
+
+
+@pytest.mark.mpi
+def test_mpi_checkpoint_resume():
+    """Test resuming from manually generated checkpoint."""
+    # Generate test data
+    data = Data(seed=SEED)
+    data.generate_mute_data(n_samples=N_SAMPLES, n_replications=1)
+
+    # Initialise analysis object and define settings
+    filename_ckp = os.path.join(
+        os.path.dirname(__file__), 'data', 'my_checkpoint')
+    network_analysis = MultivariateTE()
+    settings = {'cmi_estimator': 'JidtGaussianCMI',
+                'max_lag_sources': 3,
+                'min_lag_sources': 2,
+                'write_ckp': True,
+                'filename_ckp': filename_ckp,
+                'MPI': True,
+                'max_workers': MAX_WORKERS}
+
+    # Manually create checkpoint files for two targets.
+    # Note that variables are added as absolute time indices and not lags wrt.
+    # the current value. Internally, IDTxl operates with abolute indices, but
+    # in all results and console outputs, variables are described by their lags
+    # wrt. to the current value.
+    sources = [0, 1, 2]
+    targets = [3, 4]
+    add_vars = [[(0, 1), (0, 2), (3, 1)], [(0, 1), (0, 2), (1, 3), (4, 2)]]
+    network_analysis._set_checkpointing_defaults(
+        settings, data, sources, targets)
+    for i in range(len(targets)):
+        network_analysis._initialise(settings, data, sources, targets[i])
+        network_analysis.selected_vars_full = add_vars[i]
+        network_analysis._update_checkpoint('{}.ckp'.format(filename_ckp))
+
+    # Resume analysis.
+    network_analysis_res = MultivariateTE()
+    data, settings, targets, sources = network_analysis_res.resume_checkpoint(
+        filename_ckp)
+
+    # Test if variables were added correctly
+    for i in range(len(targets)):
+        network_analysis_res._initialise(settings, data, sources, targets[i])
+        assert network_analysis_res.selected_vars_full == add_vars[i], (
+            'Variables were not added correctly for target {0}.'.format(
+                targets[i]))
+
+    # Test if analysis runs from resumed checkpoint.
+    network_analysis_res.analyse_network(
+        settings=settings, data=data, targets=targets, sources=sources)
+
+    _clear_ckp(filename_ckp)


### PR DESCRIPTION
Added support for MPI parallelization for serial CPU estimators.

Requires mpi4py>=3.0.0

To use MPI, all one needs to do is add a MPI=True flag in the Estimator settings dictionary (one can optionally provide a n_workers argument) and start the script using

mpiexec -n 1 -usize <max workers + 1> python <python script>

on systems with MPI>=2.0 or

mpiexec -n <max workers + 1> python -m mpi4py.futures <python script>

on legacy MPI 1 implementations.

Internally, added class MPIEstimator, which is a decorator for arbitrary serial (is_parallel()==False) Estimators sending chunks of data to individual Estimator instances on MPI worker ranks using mpi4py.futures.

Limitations:
- MPIEstimator does not yet properly work with Estimators which are already parallel themselves
- GPU support has not yet been implemented / tested

Auxiliary changes:
- Strictly call Estimator.estimate with kwargs only (as the abstract method implies)
- Replaced find_estimator with get_estimator factory method to support automatic MPI decoration
- Added some unit tests for MPI